### PR TITLE
[#36] - refactor: photo format

### DIFF
--- a/partials/index.carousel.partial.html
+++ b/partials/index.carousel.partial.html
@@ -3,19 +3,19 @@
         <h2 class="section-heading">Наші роботи</h2>
     </div>
     <div class="owl-carousel owl-theme">
-        <div class="item"><img src="img/carousel/IMG_7326.JPG" alt="Photo 1"></div>
-        <div class="item"><img src="img/carousel/IMG_7771.JPG" alt="Photo 2"></div>
+        <div class="item"><img src="img/carousel/IMG_7326.jpg" alt="Photo 1"></div>
+        <div class="item"><img src="img/carousel/IMG_7771.jpg" alt="Photo 2"></div>
         <div class="item"><img src="img/carousel/IMG_7776.jpg" alt="Photo 4"></div>
         <div class="item"><img src="img/carousel/interior.jpg" alt="Photo 6"></div>
-        <div class="item"><img src="img/carousel/IMG_7519.JPG" alt="Photo 7"></div>
+        <div class="item"><img src="img/carousel/IMG_7519.jpg" alt="Photo 7"></div>
         <div class="item"><img src="img/carousel/IMG_7780.jpg" alt="Photo 8"></div>
         <div class="item"><img src="img/carousel/IMG_7781.jpg" alt="Photo 9"></div>
         <div class="item"><img src="img/carousel/IMG_7782.jpg" alt="Photo 10"></div>
         <div class="item"><img src="img/carousel/IMG_7787.jpg" alt="Photo 11"></div>
         <div class="item"><img src="img/carousel/IMG_7788.jpg" alt="Photo 12"></div>
         <div class="item"><img src="img/carousel/IMG_7790.jpg" alt="Photo 13"></div>
-        <div class="item"><img src="img/carousel/IMG_7401.JPG" alt="Photo 14"></div>
-        <div class="item"><img src="img/carousel/IMG_7519.JPG" alt="Photo 15"></div>
+        <div class="item"><img src="img/carousel/IMG_7401.jpg" alt="Photo 14"></div>
+        <div class="item"><img src="img/carousel/IMG_7519.jpg" alt="Photo 15"></div>
         <div class="item"><img src="img/carousel/interior-2.jpg" alt="Photo 17"></div>
     </div>
 </section>


### PR DESCRIPTION
This pull request includes a small but important change to the `partials/index.carousel.partial.html` file. The change standardizes the file extensions for image sources in the carousel from `.JPG` to `.jpg`.

* Standardized image file extensions from `.JPG` to `.jpg` to ensure consistency and avoid potential issues with case sensitivity in different environments. (`partials/index.carousel.partial.html`)