### PR TITLE
change backend url

### DIFF
--- a/js/bookingform.js
+++ b/js/bookingform.js
@@ -9,7 +9,7 @@ document.getElementById('contactForm').addEventListener('submit', function(e) {
         phone: phone
     };
 
-    fetch('http://localhost:8081/send', {
+    fetch('http://backend:8081/send', {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json'

--- a/js/price-list.js
+++ b/js/price-list.js
@@ -1,5 +1,5 @@
 // URL для вашого REST API
-const apiUrl = 'http://localhost:8081/price_list';
+const apiUrl = 'http://backend:8081/price_list';
 const localStorageKey = 'priceListData'; 
 const expirationKey = 'priceListExpiration';
 


### PR DESCRIPTION
This pull request includes changes to update API endpoint URLs in the JavaScript files to point to the backend server instead of localhost.

API endpoint updates:

* [`js/bookingform.js`](diffhunk://#diff-c55bc617b1302af24b2ce2516a5fee71bb48933571a429cc30fef9d1e43608a4L12-R12): Updated the `fetch` URL in the contact form submission to use `http://backend:8081/send` instead of `http://localhost:8081/send`.
* [`js/price-list.js`](diffhunk://#diff-59345d772092288c3c4d30d5f52a3b6ad234dadbb2d6e872fdf136becae404c6L2-R2): Updated the `apiUrl` variable to use `http://backend:8081/price_list` instead of `http://localhost:8081/price_list`.