### PR TITLE
[#49] - fix: margin text

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -16,7 +16,6 @@
 
 .text-content {
     text-align: left;
-    margin: 3rem 2rem;
     padding: 1rem;
 }
 


### PR DESCRIPTION
This pull request includes a small change to the `css/about.css` file. The change removes the margin property from the `.text-content` class to adjust the layout.