### PR TITLE
[#49] - fix: padding banner text

### DIFF
--- a/css/header.css
+++ b/css/header.css
@@ -252,33 +252,16 @@ video {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  row-gap: 1rem;
-  overflow: visible;
-  width: 100%;
-  padding: 0 1rem;
-}
-.menu-item {
-  position: relative;
-  width: 100%;
-  text-align: center;
-  transition: transform 0.3s ease;
-}
-.menu-item:hover {
-  transform: scale(1.3);
+  row-gap: 1.25rem;
 }
 .menu-link {
-  display: inline-block;
-  width: auto;
-  white-space: nowrap;
   font-family: inherit;
   font-size: 1rem;
   font-weight: 500;
   line-height: 1.5;
   color: var(--color-white-100);
   text-transform: uppercase;
-}
-.menu-link:hover {
-  transform: none;
+  transition: all 0.3s ease;
 }
 .menu-block {
   display: inline-block;
@@ -299,16 +282,7 @@ video {
   color: var(--color-black-200);
   background-color: var(--color-white-200);
   box-shadow: var(--shadow-medium);
-  transition: all 0.6s ease;
-  cursor: pointer;
-}
-.menu-block:hover {
-  background-color: var(--color-black-600);
-  color: var(--color-white-100);
-  box-shadow: 0 0 1rem rgba(255, 255, 255, 0.5);
-}
-.menu-block:active {
-  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.5);
+  transition: all 0.3s ease-in-out;
 }
 @media screen and (min-width: 21rem) {
   .menu-block {
@@ -501,12 +475,12 @@ video {
   display: grid;
   align-items: center;
   row-gap: 3rem;
-  padding: 9rem 1rem;
+  padding: 9rem 2rem;
 }
 @media only screen and (min-width: 48rem) {
   .banner-column {
     grid-template-columns: 1fr 1fr;
-    padding: 4rem 1rem 9rem 1rem;
+    padding: 4rem 1rem 9rem 2rem;
   }
 }
 @media only screen and (min-width: 64rem) {
@@ -514,7 +488,7 @@ video {
     grid-template-columns: 1fr max-content;
     -moz-column-gap: 4rem;
          column-gap: 4rem;
-    padding: 7rem 1rem 9rem 1rem;
+    padding: 7rem 1rem 9rem 2rem;
   }
 }
 .banner-image.active {

--- a/css/header.css
+++ b/css/header.css
@@ -252,16 +252,33 @@ video {
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  row-gap: 1.25rem;
+  row-gap: 1rem;
+  overflow: visible;
+  width: 100%;
+  padding: 0 1rem;
+}
+.menu-item {
+  position: relative;
+  width: 100%;
+  text-align: center;
+  transition: transform 0.3s ease;
+}
+.menu-item:hover {
+  transform: scale(1.3);
 }
 .menu-link {
+  display: inline-block;
+  width: auto;
+  white-space: nowrap;
   font-family: inherit;
   font-size: 1rem;
   font-weight: 500;
   line-height: 1.5;
   color: var(--color-white-100);
   text-transform: uppercase;
-  transition: all 0.3s ease;
+}
+.menu-link:hover {
+  transform: none;
 }
 .menu-block {
   display: inline-block;
@@ -282,7 +299,16 @@ video {
   color: var(--color-black-200);
   background-color: var(--color-white-200);
   box-shadow: var(--shadow-medium);
-  transition: all 0.3s ease-in-out;
+  transition: all 0.6s ease;
+  cursor: pointer;
+}
+.menu-block:hover {
+  background-color: var(--color-black-600);
+  color: var(--color-white-100);
+  box-shadow: 0 0 1rem rgba(255, 255, 255, 0.5);
+}
+.menu-block:active {
+  box-shadow: 0 0 1rem rgba(0, 0, 0, 0.5);
 }
 @media screen and (min-width: 21rem) {
   .menu-block {


### PR DESCRIPTION
This pull request includes a minor change to the `css/header.css` file to adjust the padding for different screen sizes. The change increases the right padding from 1rem to 2rem in three different media queries.

Changes to padding:

* [`css/header.css`](diffhunk://#diff-027cddac6436c667eba00d3fbefce85c72f749b128a17848c7d2110d2fc58cdcL504-R517): Increased the right padding from 1rem to 2rem in the default, 48rem, and 64rem media queries.