### PR TITLE
[#57] - fix: Elastic Scrolling

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -76,6 +76,8 @@ body {
    -ms-overflow-style: none;
 }
 
+body, html { overscroll-behavior: none; }
+
 body::-webkit-scrollbar {
    display: none;
 }


### PR DESCRIPTION
# Summary of changes #57 

* [`css/global.css`](diffhunk://#diff-dff778cd66ec34cbc350ebd060870d6cef6e750ec0efd0373be6fdaab3bf85c7R79-R80): Added `overscroll-behavior: none;` to the `body` and `html` elements to prevent overscroll behavior.